### PR TITLE
fix: remove unregistered fsspec-wrapper dependency (dependency confusion)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.2.11"
 
 dependencies = [
   "virtualenv",
-  "fsspec-wrapper",
+  "fsspec",
   "nni",
   "datasets",
   "mlflow-skinny",


### PR DESCRIPTION
## Summary

`fsspec-wrapper` listed in `pyproject.toml` is not a registered PyPI package. `fsspec` is the canonical package; `fsspec-wrapper` appears to be an internal Microsoft wrapper that was never published to PyPI.

Because pip resolves all dependencies from PyPI by default, any `pip install FabricSync` will query PyPI for `fsspec-wrapper`. If an attacker registers that name on PyPI, they gain code execution in every environment that installs this package.

## Changes

- `pyproject.toml`: replace `fsspec-wrapper` with `fsspec`

## Security Impact

Dependency confusion — unregistered package name in `dependencies` is squattable on PyPI. An attacker registering `fsspec-wrapper` with a valid version gains remote code execution on install.

## Test plan

- [ ] Verify `pip install .` resolves `fsspec` correctly after this change
- [ ] Confirm no internal code imports from a module named `fsspec_wrapper` (if so, a shim or vendored module may be needed)
